### PR TITLE
Update build for Cordova + instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Ignore Cordova/Phonegap `platforms/` & `plugins/` folders - rebuild locally
+platforms/
+plugins/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -62,3 +62,11 @@ OR
 
 $ cordova build android
 ```
+
+
+## For Testing The Project
+To test for the Android project, open it (`platforms/android`) in Android Studio.
+
+Likewise for testing the iOS app, open it (`platforms/ios`) in XCode and run it in the emulator there.
+
+There's ways to do this from the command line but `¯\_(ツ)_/¯`.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,64 @@
+Metropolis of Science
+======================
+Mobile app for [Metropolis of Science](http://metropolisofscience.org/) created and maintained by students in the [M.A. Science, Environment and Medicine Journalism Program at the Columbia University Graduate School of Journalism](https://journalism.columbia.edu/ma-science-environment-medicine). This mobile app was developed by @juanfrans and is built using [Apache Cordova](https://cordova.apache.org).
+
+# Installation and Build
+## Prerequisites
+This application uses [Apache Cordova](https://cordova.apache.org) to build mobile applications for Apple iOS (iPhone) and Google Android.
+
+1. [Install nodejs & npm](https://nodejs.org/en/)
+2. Install Apache Cordova `$ npm install -g cordova` or `$ sudo npm install -g cordova`
+3.
+Additional details on installing cordova can be found in the [official cordova installation guide](https://cordova.apache.org/docs/en/latest/guide/cli/#installing-the-cordova-cli).
+
+### iOS Prerequisites
+To build for iOS you MUST run this build on a Mac (or theoretically using [Adobe's Phonegap Build](https://build.phonegap.com/) service, though I haven't tested this).
+
+**Follow the [Cordova iOS Guide](https://cordova.apache.org/docs/en/latest/guide/platforms/ios/index.html).** The instructions here are **critical** for deploying to the Apple App Store.
+
+#### the short version
+1. Install XCode
+2. Install XCode command line tools: `$ xcode-select --install`
+3. Install npm packages [ios-sim](https://www.npmjs.org/package/ios-sim) & [ios-deploy](https://www.npmjs.org/package/ios-deploy)
+```
+$ npm install -g ios-sim
+$ npm install -g ios-deploy
+```
+
+### Android Prerequisites
+[¯\_(ツ)_/¯](https://cordova.apache.org/docs/en/latest/guide/platforms/android/index.html)
+
+#### Basically...
+1. Install [Android Studio](https://developer.android.com/studio/index.html)
+2. Launch Android Studio, which will download and install A Whole Lot of Google Onto Your Computer
+3. Launch the android sdk manager (on a mac it's at `$ ~/Library/Android/tools/android`), and use it to install:
+  * "SDK Platform" for android-23 (AKA: Android 6.0 (API 23) -> SDK Platform)
+  * "Android SDK Platform-tools (latest)
+  * "Android SDK Build-tools" (latest)
+
+Now things _should_ build.
+
+# Building the Project
+## For Mucking around
+The first time you start working with this project, you'll need to create versions for ios and android.
+
+```
+$ cordova platform add ios --save
+$ cordova platform add android --save
+```
+
+Beyond that, when you update the project, you can just run:
+
+```
+$ cordova build
+```
+
+Or to update the project just for iOS (or just Android), run:
+
+```
+$ cordova build ios
+
+OR
+
+$ cordova build android
+```

--- a/config.xml
+++ b/config.xml
@@ -44,44 +44,44 @@
     <feature name="Geolocation">
         <param name="ios-package" value="CDVLocation" />
     </feature>
-    <icon src="icon.png" />
+    <icon src="www/icon.png" />
     <!-- iPhone 6 / 6+ -->
-    <icon platform="ios" src="icon-60@3x.png" width="180" height="180" />
+    <icon platform="ios" src="www/icon-60@3x.png" width="180" height="180" />
     <!-- iPhone / iPod Touch  -->
-    <icon platform="ios" src="icon-60.png" width="60" height="60" />
-    <icon platform="ios" src="icon-60@2x.png" width="120" height="120" />
+    <icon platform="ios" src="www/icon-60.png" width="60" height="60" />
+    <icon platform="ios" src="www/icon-60@2x.png" width="120" height="120" />
     <!-- iPad -->
-    <icon platform="ios" src="icon-76.png" width="76" height="76" />
-    <icon platform="ios" src="icon-76@2x.png" width="152" height="152" />
+    <icon platform="ios" src="www/icon-76.png" width="76" height="76" />
+    <icon platform="ios" src="www/icon-76@2x.png" width="152" height="152" />
     <!-- Settings Icon -->
-    <icon platform="ios" src="icon-small.png" width="29" height="29" />
-    <icon platform="ios" src="icon-small@2x.png" width="58" height="58" />
+    <icon platform="ios" src="www/icon-small.png" width="29" height="29" />
+    <icon platform="ios" src="www/icon-small@2x.png" width="58" height="58" />
     <!-- Spotlight Icon -->
-    <icon platform="ios" src="icon-40.png" width="40" height="40" />
-    <icon platform="ios" src="icon-40@2x.png" width="80" height="80" />
+    <icon platform="ios" src="www/icon-40.png" width="40" height="40" />
+    <icon platform="ios" src="www/icon-40@2x.png" width="80" height="80" />
     <!-- iPhone / iPod Touch -->
-    <icon platform="ios" src="icon.png" width="57" height="57" />
-    <icon platform="ios" src="icon@2x.png" width="114" height="114" />
+    <icon platform="ios" src="www/icon.png" width="57" height="57" />
+    <icon platform="ios" src="www/icon@2x.png" width="114" height="114" />
     <!-- iPad -->
-    <icon platform="ios" src="icon-72.png" width="72" height="72" />
-    <icon platform="ios" src="icon-72@2x.png" width="144" height="144" />
+    <icon platform="ios" src="www/icon-72.png" width="72" height="72" />
+    <icon platform="ios" src="www/icon-72@2x.png" width="144" height="144" />
     <!-- iPhone Spotlight and Settings Icon -->
-    <icon platform="ios" src="icon-small.png" width="29" height="29" />
-    <icon platform="ios" src="icon-small@2x.png" width="58" height="58" />
+    <icon platform="ios" src="www/icon-small.png" width="29" height="29" />
+    <icon platform="ios" src="www/icon-small@2x.png" width="58" height="58" />
     <!-- iPad Spotlight and Settings Icon -->
-    <icon platform="ios" src="icon-50.png" width="50" height="50" />
-    <icon platform="ios" src="icon-50@2x.png" width="100" height="100" />
+    <icon platform="ios" src="www/icon-50.png" width="50" height="50" />
+    <icon platform="ios" src="www/icon-50@2x.png" width="100" height="100" />
 
-    <splash src="splash.png" />
+    <splash src="www/splash.png" />
     <!-- iPhone and iPod touch -->
-    <splash platform="ios" src="Default.png" width="320" height="480" />
-    <splash platform="ios" src="Default@2x.png" width="640" height="960" />
+    <splash platform="ios" src="www/Default.png" width="320" height="480" />
+    <splash platform="ios" src="www/Default@2x.png" width="640" height="960" />
     <!-- iPhone 5 / iPod Touch (5th Generation) -->
-    <splash platform="ios" src="Default-568h@2x.png" width="640" height="1136" />
+    <splash platform="ios" src="www/Default-568h@2x.png" width="640" height="1136" />
     <!-- iPhone 6 -->
-    <splash platform="ios" src="Default-667h@2x.png" width="750" height="1334" />
-    <splash platform="ios" src="Default-Portrait-736h@3x.png" width="1242" height="2208" />
-    <splash platform="ios" src="Default-Landscape-736h@3x.png" width="2208" height="1242" />
+    <splash platform="ios" src="www/Default-667h@2x.png" width="750" height="1334" />
+    <splash platform="ios" src="www/Default-Portrait-736@3x.png" width="1242" height="2208" />
+    <splash platform="ios" src="www/Default-Landscape-736@3x.png" width="2208" height="1242" />
 
     <access origin="*" />
     <plugin name="cordova-plugin-whitelist" version="1" />


### PR DESCRIPTION
Edits project configuration so application will build for iOS + Android, as well as project instructions in readme.

Build updates:
- Changes locations of icons & splash screens so build script can be run from project root

Readme contains:
- Prerequisites for Cordova
- Installing build components for iOS and Android
